### PR TITLE
more unbound tests, more support for unbound adds in m2m situations

### DIFF
--- a/tests/test_m2mhelper.py
+++ b/tests/test_m2mhelper.py
@@ -188,3 +188,27 @@ def test_m2m_subsorts():
     srt = sorted(grp1.peeps)
 
     assert srt == expect
+
+
+@pytest.mark.parametrize("who_adds", [Group, Peep])
+def test_m2m_unbound(who_adds):
+    db = SqliteDb(":memory:")
+    mgr = Harbinger(db, groups=Groups, peeps=Peeps, group_peeps=GroupPeeps)
+    mgr.groups = Groups(mgr)
+    mgr.peeps = mgr[Peeps]
+    grp1 = Group(id=1, data="g1")
+    peep1 = Peep(id=2, data="p1")
+    grp1.peeps.add(peep1, role="role")
+
+    assert peep1 in grp1.peeps
+    assert peep1.id in grp1.peeps
+
+    if who_adds is Group:
+        mgr.groups.add(grp1)
+    else:
+        mgr.peeps.add(peep1)
+
+    assert peep1.id in mgr.peeps
+    assert peep1.id in grp1.peeps
+    assert peep1 in mgr.peeps
+    assert peep1 in grp1.peeps

--- a/tests/test_omen.py
+++ b/tests/test_omen.py
@@ -856,3 +856,18 @@ def test_multi_pk_issues():
     b.subs.add(Sub(sub="what"))
 
     assert db.select_one("subs", id1=4, id2=5).sub == "what"
+
+
+def test_unbound_add():
+    db = SqliteDb(":memory:")
+    mgr = MyOmen(db)
+    mgr.cars = Cars(mgr)
+    car = Car(id=44, gas_level=0, color="green")
+    door = gen_objs.doors_row(type="a")
+    car.doors.add(door)
+    assert door.carid == car.id
+    assert door.carid
+    assert door in car.doors
+    assert car.doors.select_one(type="a")
+    mgr.cars.add(car)
+    assert db.select_one("doors", carid=car.id, type="a")


### PR DESCRIPTION
allows you to add unbound things to m2m helpers, and it does the right thing

- add related objects
- commit all nested objects together