### PR TITLE
compat autocreate

### DIFF
--- a/omen2/omen.py
+++ b/omen2/omen.py
@@ -206,7 +206,8 @@ class Omen(abc.ABC):
         mod2 = self.model
         for tab in self.AUTOCREATE_IGNORE_TABLES:
             mod1.pop(tab, None)
-        if not mod1 == mod2:
+            mod2.pop(tab, None)
+        if not sorted(mod1.keys()) == sorted(mod2.keys()):
             self.__multi_query(self.db, self.schema(self.version))
 
     @classmethod

--- a/omen2/omen.py
+++ b/omen2/omen.py
@@ -32,6 +32,10 @@ class Omen(abc.ABC):
     model: DbModel = None
     table_types: Dict[str, Type["Table"]] = None
 
+    # todo: deprecate this
+    AUTOCREATE = True
+    AUTOCREATE_IGNORE_TABLES = ["_omen"]
+
     def __init_subclass__(cls, **_kws):
         cls.table_types = {}
 
@@ -47,7 +51,8 @@ class Omen(abc.ABC):
         self.tables: Dict[Type["Table"], "Table"] = {}
         self.db = db
 
-        self._create_if_needed()
+        if self.AUTOCREATE:
+            self._create_if_needed()
 
         self.table_types.update(table_types)
 
@@ -199,8 +204,8 @@ class Omen(abc.ABC):
         # TODO: this should be removed, not good behavior
         mod1 = self.db.model()
         mod2 = self.model
-        mod1.pop("_omen", None)
-        mod2.pop("_omen", None)
+        for tab in self.AUTOCREATE_IGNORE_TABLES:
+            mod1.pop(tab, None)
         if not mod1 == mod2:
             self.__multi_query(self.db, self.schema(self.version))
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def long_description():
 
 setup(
     name="omen2",
-    version="1.5.1",
+    version="1.5.2",
     description="Database object & cache manager",
     packages=["omen2"],
     long_description=long_description(),

--- a/tests/test_omen.py
+++ b/tests/test_omen.py
@@ -1203,12 +1203,13 @@ def test_sync_on_getattr():
     ok = False
     event1 = threading.Event()
     event2 = threading.Event()
+
     def _other():
         nonlocal ok
         event1.wait()
         ok = car.color == "intx"
         event2.set()
-    
+
     threading.Thread(target=_other, daemon=True).start()
 
     with car:
@@ -1222,8 +1223,7 @@ def test_sync_on_getattr():
 
     assert db.select_one("cars", id=car.id).color == "commit"
 
-    
-        
+
 def test_cache_sharing():
     db = SqliteDb(":memory:")
     mgr = MyOmen(db)


### PR DESCRIPTION
autocreate is evil, make it optional at least.   will deprecate at some point or provide a better interface