### PR TITLE
selectable test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [3.6, 3.7, 3.9]
+        python: [3.7, 3.9]
     name: ${{matrix.os}} ${{ matrix.python }}
     steps:
     - uses: actions/checkout@v2

--- a/omen2/selectable.py
+++ b/omen2/selectable.py
@@ -66,6 +66,7 @@ class Selectable(Generic[T]):
 
         try:
             next(itr)
+            itr.close()
             raise OmenMoreThanOneError
         except StopIteration:
             return one

--- a/tests/test_omen.py
+++ b/tests/test_omen.py
@@ -9,7 +9,7 @@ import threading
 import time
 from contextlib import suppress
 from multiprocessing.pool import ThreadPool
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from types import ModuleType
 
 import pytest
@@ -1361,6 +1361,52 @@ def test_no_upsert_on_existing():
     with car:
         car.gas_level = 5
     assert not mgr.cars.select_one(id=12)
+
+
+def test_omen_fetch_close_select_one():
+    db = SqliteDb(":memory:")
+    mgr = MyOmen(db)
+    mgr.cars = Cars(mgr)
+
+    db.insert("cars", id=12, gas_level=0, color="green")
+    db.insert("cars", id=13, gas_level=0, color="green")
+    db.insert("cars", id=14, gas_level=0, color="green")
+    db.insert("cars", id=15, gas_level=0, color="green")
+
+    orig_exec = mgr.db.execute
+
+    # allows us to mock the return call without altering the result set / behavior
+    class Wrap(object):
+        def __init__(self, obj):
+            self._wrapped_obj = obj
+
+        def __getattr__(self, attr):
+            if attr in self.__dict__:
+                return getattr(self, attr)
+            return getattr(self._wrapped_obj, attr)
+
+    def new_exec(*a, **k):
+        # returns a wrapped cursor that has a trackabale close funcion
+        nonlocal check_mock
+        ret = orig_exec(*a, **k)
+        ret = Wrap(ret)
+        ret.close = MagicMock(side_effect=ret._wrapped_obj.close)
+        check_mock = ret.close
+        return ret
+
+    check_mock = None
+
+    # this holds a reference to the iterator, so it won't GeneratorExit on __del__
+    ref_holder = []
+    with patch.object(mgr.db, "execute", new_exec):
+        with pytest.raises(OmenMoreThanOneError):
+            itr = mgr.cars.select(color="green")
+            ref_holder.append(itr)
+
+            # fails because more than one
+            mgr.cars._return_one(itr)
+
+        check_mock.assert_called()
 
 
 def test_explicit_upsert():


### PR DESCRIPTION
explicit close happens sooner than when relying on __del__